### PR TITLE
Include support for updating metadata element using a uuid and use for iso19115/iso19139 profiles

### DIFF
--- a/src/main/java/it/geosolutions/geonetwork/GNClient.java
+++ b/src/main/java/it/geosolutions/geonetwork/GNClient.java
@@ -32,6 +32,7 @@ import it.geosolutions.geonetwork.exception.GNServerException;
 import it.geosolutions.geonetwork.op.GNInfo;
 import it.geosolutions.geonetwork.op.GNMetadataDelete;
 import it.geosolutions.geonetwork.op.GNMetadataGet;
+import it.geosolutions.geonetwork.op.GNMetadataGetId;
 import it.geosolutions.geonetwork.op.GNMetadataGetInfo;
 import it.geosolutions.geonetwork.op.GNMetadataGetInfo.MetadataInfo;
 import it.geosolutions.geonetwork.op.GNMetadataGetVersion;
@@ -128,6 +129,12 @@ public class GNClient {
     public void updateMetadata(long id, File metadataFile) throws GNLibException, GNServerException {
         String version = GNMetadataGetVersion.get(connection, gnServiceURL, id);
         GNMetadataUpdate.update(connection, gnServiceURL, id, version, metadataFile);
+    }
+
+    public void updateMetadata(String uuid, Element metadataElement) throws GNLibException, GNServerException {
+        long id = GNMetadataGetId.get(connection, gnServiceURL, uuid);
+        String version = GNMetadataGetVersion.get(connection, gnServiceURL, id);
+        GNMetadataUpdate.update(connection, gnServiceURL, id, version, metadataElement);  
     }
 
     public void updateMetadata(long id, int version, File metadataFile) throws GNLibException, GNServerException {

--- a/src/main/java/it/geosolutions/geonetwork/op/GNMetadataUpdate.java
+++ b/src/main/java/it/geosolutions/geonetwork/op/GNMetadataUpdate.java
@@ -54,13 +54,21 @@ public class GNMetadataUpdate {
     public static void update(HTTPUtils connection, String gnServiceURL, Long id, String version, File inputFile)  throws GNLibException, GNServerException {
         if(LOGGER.isInfoEnabled())
             LOGGER.info("Using metadata file " + inputFile);
-        Element updateRequest = buildUpdateRequest(inputFile, id, version);
-
-        // updatethe metadata
-        LOGGER.debug("Updating metadata " + id + " version " + version);
-        gnUpdateMetadata(connection, gnServiceURL, updateRequest);
-        LOGGER.info("Updated metadata " + id + " version " + version);
+        Element metadataFromFile = parseFile(inputFile);
+        update(connection, gnServiceURL, id, version, metadataFromFile);
     }
+
+    /**
+    *
+    */
+    public static void update(HTTPUtils connection, String gnServiceURL, Long id, String version, Element inputElement)  throws GNLibException, GNServerException {
+       Element updateRequest = buildUpdateRequest(inputElement, id, version); 
+
+       // update the metadata
+       LOGGER.debug("Updating metadata " + id + " version " + version);
+       gnUpdateMetadata(connection, gnServiceURL, updateRequest);
+       LOGGER.info("Updated metadata " + id + " version " + version);
+   }
 
     /**
      * Creates a Request document for the geonetwork <tt>metadata.update</tt> operation.
@@ -73,14 +81,12 @@ public class GNMetadataUpdate {
      * <li>data (mandatory) Contains the metadata record</li>
      * </ul>
      */
-    private static Element buildUpdateRequest(File inputFile, Long id, String version)  throws GNLibException, GNServerException {
+    private static Element buildUpdateRequest(Element metadataElement, Long id, String version)  throws GNLibException, GNServerException {
         if(LOGGER.isDebugEnabled()) 
             LOGGER.debug("Compiling request document");
         
-        Element metadataFromFile = parseFile(inputFile);
-
         XMLOutputter outputter = new XMLOutputter(Format.getRawFormat());
-        CDATA cdata = new CDATA(outputter.outputString(metadataFromFile)); // CDATA format is required by GN
+        CDATA cdata = new CDATA(outputter.outputString(metadataElement)); // CDATA format is required by GN
         
         Element request = new Element("request");
         request.addContent(new Element("id").setText(String.valueOf(id)));
@@ -94,7 +100,7 @@ public class GNMetadataUpdate {
      * Insert a metadata in GN.<br/>
      * 
      * <ul>
-     * <li>Url: <tt>http://<i>server</i>:<i>port</i>/geonetwork/srv/en/metadata.update</tt></li>
+     * <li>Url: <tt>http://<i>server</i>:<i>port</i>/geonetwork/srv/en/metadata.update.finish</tt></li>
      * <li>Mime-type: <tt>application/xml</tt></li>
      * <li>Post request: <pre>{@code 
      * 


### PR DESCRIPTION
Hi,

Wondering whether these changes would be acceptable for inclusion in your code base.  We are looking to use your library, but for our use case we would like to be able to update using a jdom element created in our java process rather than loading from a file.   We also use a profile of iso19115/iso19139 so had to make some changes to support that.

While we can and will maintain a fork of your repo, if these changes are useful to others, it would be good if they could be included in your repo to make them more widely accessible.


Thanks,
CraigJ